### PR TITLE
Remove annotations for easily inferred types

### DIFF
--- a/src/github_client.rs
+++ b/src/github_client.rs
@@ -40,18 +40,20 @@ impl GithubClient {
     }
 
     fn get_html_url(&self, notification: GithubNotification) -> Result<NotificationWithUrl, Error> {
-        let response: Response = self.get(&notification.subject.url)?;
+        let response = self.get(&notification.subject.url)?;
         let url: HasHtmlUrl = response.json::<HasHtmlUrl>()?;
         Ok(NotificationWithUrl::new(notification, url))
     }
 
-    pub fn fetch_notifications(&self, since: DateTime<Local>) -> Result<Vec<NotificationWithUrl>, Error> {
-        let response: Response = self.get_notifications(since)?;
+    pub fn fetch_notifications(
+        &self,
+        since: DateTime<Local>,
+    ) -> Result<Vec<NotificationWithUrl>, Error> {
+        let response = self.get_notifications(since)?;
         let notifications: Vec<GithubNotification> = response.json::<Vec<GithubNotification>>()?;
         notifications
             .into_iter()
-            .map(|notification|
-                self.get_html_url(notification)
-            ).collect()
+            .map(|notification| self.get_html_url(notification))
+            .collect()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,9 @@ extern crate reqwest;
 
 use std::{env, thread, time};
 
-use chrono::{DateTime, Local};
-use reqwest::Error;
+use chrono::Local;
 
 use crate::github_client::GithubClient;
-use crate::github_notification::NotificationWithUrl;
 use crate::slack_client::SlackClient;
 use crate::slack_message::SlackMessage;
 
@@ -19,26 +17,24 @@ mod slack_message;
 const POLLING_FREQUENCY: time::Duration = time::Duration::from_secs(30);
 
 fn main() {
-    let github_username: String = env::var("GITHUB_USERNAME").expect("No GITHUB_USERNAME env var.");
-    let github_token: String = env::var("GITHUB_TOKEN").expect("No GITHUB_TOKEN env var.");
-    let slack_hook: String = env::var("SLACK_HOOK").expect("No SLACK_HOOK env var.");
+    let github_username = env::var("GITHUB_USERNAME").expect("No GITHUB_USERNAME env var.");
+    let github_token = env::var("GITHUB_TOKEN").expect("No GITHUB_TOKEN env var.");
+    let slack_hook = env::var("SLACK_HOOK").expect("No SLACK_HOOK env var.");
 
-    let github: GithubClient = GithubClient::new(github_username, github_token);
-    let slack: SlackClient = SlackClient::new(slack_hook);
+    let github = GithubClient::new(github_username, github_token);
+    let slack = SlackClient::new(slack_hook);
 
-    let mut last_fetch_time: DateTime<Local> = Local::now();
+    let mut last_fetch_time = Local::now();
 
-    let initialization_message: SlackMessage =
-        SlackMessage::new(format!("Initialized at {:?}", last_fetch_time));
+    let initialization_message = SlackMessage::new(format!("Initialized at {:?}", last_fetch_time));
     slack.post(&initialization_message).unwrap();
 
     loop {
-        let time_before_fetch: DateTime<Local> = Local::now();
+        let time_before_fetch = Local::now();
 
-        let maybe_notifications: Result<Vec<NotificationWithUrl>, Error> =
-            github.fetch_notifications(last_fetch_time);
+        let maybe_notifications = github.fetch_notifications(last_fetch_time);
 
-        let notifications: Vec<NotificationWithUrl> = match maybe_notifications {
+        let notifications = match maybe_notifications {
             Ok(notifications) => {
                 println!("Got notifications from github: {:?}.", notifications);
                 last_fetch_time = time_before_fetch;
@@ -52,7 +48,7 @@ fn main() {
         };
 
         for notification in notifications {
-            let message: SlackMessage = SlackMessage::from_notification(&notification);
+            let message = SlackMessage::from_notification(&notification);
             slack.post(&message).unwrap();
         }
 

--- a/src/slack_message.rs
+++ b/src/slack_message.rs
@@ -21,7 +21,7 @@ impl SlackMessage {
     }
 
     pub fn from_notification(notification: &NotificationWithUrl) -> Self {
-        let message: String = format!(
+        let message = format!(
             "{kind} from GitHub at {url}",
             kind = notification.subject.kind,
             url = notification.url,


### PR DESCRIPTION
Keep annotations for things deserialized with serde because some IDEs
(IntelliJ) can't infer those types properly on their own.