### PR TITLE
Remove incorrect field on GithubNotification

### DIFF
--- a/src/github_notification.rs
+++ b/src/github_notification.rs
@@ -12,7 +12,6 @@ pub struct Subject {
 #[derive(Deserialize, Debug)]
 pub struct GithubNotification {
     id: String,
-    private: Option<bool>,
     pub subject: Subject,
     reason: String,
     unread: bool,


### PR DESCRIPTION
This field is unused and was actually a member of a further nested data
structure.