### PR TITLE
Update message format to conatin more useful info

### DIFF
--- a/src/github_notification.rs
+++ b/src/github_notification.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct Subject {
-    title: String,
+    pub title: String,
     pub url: String,
     latest_comment_url: String,
     #[serde(rename = "type")]
@@ -13,7 +13,7 @@ pub struct Subject {
 pub struct GithubNotification {
     id: String,
     pub subject: Subject,
-    reason: String,
+    pub reason: String,
     unread: bool,
     updated_at: String,
     last_read_at: Option<String>,
@@ -28,14 +28,14 @@ pub struct HasHtmlUrl {
 
 #[derive(Debug)]
 pub struct NotificationWithUrl {
-    pub subject: Subject,
+    pub notification: GithubNotification,
     pub url: String,
 }
 
 impl NotificationWithUrl {
     pub fn new(notification: GithubNotification, url: HasHtmlUrl) -> Self {
         Self {
-            subject: notification.subject,
+            notification,
             url: url.html_url,
         }
     }

--- a/src/slack_message.rs
+++ b/src/slack_message.rs
@@ -20,8 +20,10 @@ impl SlackMessage {
 
     pub fn from_notification(notification: &NotificationWithUrl) -> Self {
         let message = format!(
-            "{kind} from GitHub at {url}",
-            kind = notification.subject.kind,
+            "{kind} - {title}\n*{reason}*\n{url}",
+            kind = notification.notification.subject.kind,
+            title = notification.notification.subject.title,
+            reason = notification.notification.reason,
             url = notification.url,
         );
         Self::new(message)


### PR DESCRIPTION
This changes the slack post format to contain more information about why
the notification is being sent. It also formats it more readably.