### PR TITLE
Add documentation for clients/messages

### DIFF
--- a/src/github_client.rs
+++ b/src/github_client.rs
@@ -6,6 +6,13 @@ use reqwest::Error;
 /// https://developer.github.com/v3/activity/notifications/
 const GITHUB_API_URL: &str = "https://api.github.com/notifications";
 
+/// A client to get messages from the github notification API
+///
+/// # Arguments
+///
+/// * `client` - The reqwests client that gets from the github API
+/// * `username` - A github username associated with the token
+/// * `token` - A github personal access token with notification, repo, and non-admin read scopes
 pub struct GithubClient {
     client: Client,
     username: String,
@@ -21,6 +28,7 @@ impl GithubClient {
         }
     }
 
+    /// Gets all notifications since a timestamp even if they've been read
     fn get_notifications(&self, since: DateTime<Local>) -> Result<Response, Error> {
         self.client
             .get(GITHUB_API_URL)
@@ -29,6 +37,7 @@ impl GithubClient {
             .send()
     }
 
+    /// Gets a response from an API URL
     fn get(&self, api_url: &str) -> Result<Response, Error> {
         self.client
             .get(api_url)
@@ -36,12 +45,14 @@ impl GithubClient {
             .send()
     }
 
+    /// Gets an HTML URL from a notification's API URL and bundles them together
     fn get_html_url(&self, notification: GithubNotification) -> Result<NotificationWithUrl, Error> {
         let response = self.get(&notification.subject.url)?;
         let url: HasHtmlUrl = response.json::<HasHtmlUrl>()?;
         Ok(NotificationWithUrl::new(notification, url))
     }
 
+    /// Gets all notifications since a timestamp and bundles them with a human-usable HTML URL
     pub fn fetch_notifications(
         &self,
         since: DateTime<Local>,

--- a/src/github_notification.rs
+++ b/src/github_notification.rs
@@ -1,5 +1,12 @@
 use serde::Deserialize;
 
+/// The main body of a github notification API response
+///
+/// # Arguments
+///
+/// * `title` - The title of the subject of the notification (e.g. PR title)
+/// * `url` - The API url for getting more information about the subject
+/// * `kind` - The type of the subject (e.g. PR, Issue, etc.)
 #[derive(Deserialize, Debug)]
 pub struct Subject {
     pub title: String,
@@ -9,6 +16,12 @@ pub struct Subject {
     pub kind: String,
 }
 
+/// The top level fields in a github notification API response
+///
+/// # Arguments
+///
+/// * `subject` - The body of the notification
+/// * `reason` - The reason that the notification was sent
 #[derive(Deserialize, Debug)]
 pub struct GithubNotification {
     id: String,
@@ -20,12 +33,15 @@ pub struct GithubNotification {
     url: String,
 }
 
-/// This should eventually be parted into different things for PRs, Issues, etc.
+/// The HTML URL extracted from the response to a github get request to an API URL
+///
+/// NOTE[Rhys]: There many more fields in the response they depend on what api route we actually hit
 #[derive(Deserialize, Debug)]
 pub struct HasHtmlUrl {
     pub html_url: String,
 }
 
+/// A github notification bundled with an HTML url in addition to the original API one
 #[derive(Debug)]
 pub struct NotificationWithUrl {
     pub notification: GithubNotification,

--- a/src/slack_client.rs
+++ b/src/slack_client.rs
@@ -3,6 +3,12 @@ use reqwest::Error;
 
 use crate::slack_message::SlackMessage;
 
+/// A client to send messages to the slack incoming webhook API
+///
+/// # Arguments
+///
+/// * `client` - The reqwests client that posts to the slack API
+/// * `webhook_url` - A slack incoming webhook URL
 pub struct SlackClient {
     client: Client,
     webhook_url: String,
@@ -16,6 +22,7 @@ impl SlackClient {
         }
     }
 
+    /// Posts a message to the slack incoming webhook API
     pub fn post(&self, message: &SlackMessage) -> Result<Response, Error> {
         println!("Sending slack message {}", serde_json::json!((message)));
         self.client

--- a/src/slack_message.rs
+++ b/src/slack_message.rs
@@ -2,6 +2,13 @@ use serde::Serialize;
 
 use crate::NotificationWithUrl;
 
+/// A Slack message formatted for their incoming webhook API
+///
+/// # Arguments
+///
+/// * `text` - The text body of the post; supports markdown formatting
+/// * `icon_emoji` - A slack-formatted emoji name that should be used in place of an avatar
+/// * `username` - The username associated with the post
 #[derive(Serialize, Debug)]
 pub struct SlackMessage {
     text: String,
@@ -18,6 +25,7 @@ impl SlackMessage {
         }
     }
 
+    /// Formats a github notification into the text field of a slack message
     pub fn from_notification(notification: &NotificationWithUrl) -> Self {
         let message = format!(
             "{kind} - {title}\n*{reason}*\n{url}",


### PR DESCRIPTION
Add some documentation for the github and slack clients/messages.
There're some fields omitted from the github notification
documentation since it's not immediately clear what those fields are
used for.