### PR TITLE
Build messages from anything markdownable

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -19,11 +19,11 @@ fn main() {
     let prefetch_time: Duration = Duration::hours(1);
     let mut last_fetch_time = Local::now() - prefetch_time;
 
-    let initialization_message = SlackMessage::new(format!(
+    let initialization_message = Box::new(format!(
         "Initializing at {:?} and fetching messages from the last {:?}",
         last_fetch_time, prefetch_time,
     ));
-    slack.post(&initialization_message).unwrap();
+    slack.post(initialization_message).unwrap();
 
     loop {
         let time_before_fetch = Local::now();
@@ -40,14 +40,13 @@ fn main() {
             Err(error) => {
                 let msg = format!("Failed to get GitHub notifications: {:?}.", error);
                 println!("{}", msg);
-                slack.post(&SlackMessage::new(msg)).unwrap();
+                slack.post(Box::new(msg)).unwrap();
                 Vec::new()
             }
         };
 
         for notification in notifications {
-            let message = SlackMessage::from(&notification);
-            slack.post(&message).unwrap();
+            slack.post(Box::new(notification)).unwrap();
         }
 
         thread::sleep(POLLING_FREQUENCY);

--- a/src/github_client.rs
+++ b/src/github_client.rs
@@ -1,7 +1,8 @@
-use crate::github_notification::{GithubNotification, HasHtmlUrl, NotificationWithUrl};
 use chrono::{DateTime, Local};
 use reqwest::blocking::{Client, Response};
 use reqwest::Error;
+
+use crate::{GithubNotification, HasHtmlUrl, NotificationWithUrl};
 
 /// https://developer.github.com/v3/activity/notifications/
 const GITHUB_API_URL: &str = "https://api.github.com/notifications";

--- a/src/github_notification.rs
+++ b/src/github_notification.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::Markdownable;
+
 /// The main body of a github notification API response
 ///
 /// # Arguments
@@ -54,5 +56,17 @@ impl NotificationWithUrl {
             notification,
             url: url.html_url,
         }
+    }
+}
+
+impl Markdownable for NotificationWithUrl {
+    fn markdown(&self) -> String {
+        format!(
+            "{kind} - {title}\n*{reason}*\n{url}",
+            kind = self.notification.subject.kind,
+            title = self.notification.subject.title,
+            reason = self.notification.reason,
+            url = self.url,
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
+pub use github_client::GithubClient;
+pub use github_notification::{GithubNotification, HasHtmlUrl, NotificationWithUrl};
+pub use slack_client::SlackClient;
+pub use slack_message::{Markdownable, SlackMessage};
+
 mod github_client;
 mod github_notification;
 mod slack_client;
 mod slack_message;
-
-pub use github_client::GithubClient;
-pub use github_notification::NotificationWithUrl;
-pub use slack_client::SlackClient;
-pub use slack_message::SlackMessage;

--- a/src/slack_client.rs
+++ b/src/slack_client.rs
@@ -1,7 +1,7 @@
 use reqwest::blocking::{Client, Response};
 use reqwest::Error;
 
-use crate::slack_message::SlackMessage;
+use crate::{Markdownable, SlackMessage};
 
 /// A client to send messages to the slack incoming webhook API
 ///
@@ -23,11 +23,12 @@ impl SlackClient {
     }
 
     /// Posts a message to the slack incoming webhook API
-    pub fn post(&self, message: &SlackMessage) -> Result<Response, Error> {
-        println!("Sending slack message {}", serde_json::json!((message)));
+    pub fn post(&self, text: Box<dyn Markdownable>) -> Result<Response, Error> {
+        let message = &SlackMessage::new(text);
+        println!("Sending slack message {}", serde_json::json!(message));
         self.client
             .post(&self.webhook_url)
-            .json::<SlackMessage>(message)
+            .json::<SlackMessage>(&message)
             .send()
     }
 }

--- a/src/slack_message.rs
+++ b/src/slack_message.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
 
-use crate::NotificationWithUrl;
-
 /// A Slack message formatted for their incoming webhook API
 ///
 /// https://api.slack.com/block-kit
@@ -21,26 +19,12 @@ pub struct SlackMessage {
 }
 
 impl SlackMessage {
-    pub fn new(text: String) -> Self {
+    pub fn new(text: Box<dyn Markdownable>) -> Self {
         SlackMessage {
-            blocks: vec![SectionBlock::new(text)],
+            blocks: vec![SectionBlock::new(text.markdown())],
             icon_emoji: ":chart_with_upwards_trend:".to_string(),
             username: "Github Notification Daemon".to_string(),
         }
-    }
-}
-
-impl std::convert::From<&NotificationWithUrl> for SlackMessage {
-    fn from(notification: &NotificationWithUrl) -> Self {
-        let message = format!(
-            "{kind} - {title}\n*{reason}*\n{url}",
-            kind = notification.notification.subject.kind,
-            title = notification.notification.subject.title,
-            reason = notification.notification.reason,
-            url = notification.url,
-        );
-
-        Self::new(message)
     }
 }
 
@@ -85,5 +69,15 @@ impl TextField {
             kind: String::from("mrkdwn"),
             text,
         }
+    }
+}
+
+pub trait Markdownable {
+    fn markdown(&self) -> String;
+}
+
+impl Markdownable for String {
+    fn markdown(&self) -> String {
+        self.clone()
     }
 }


### PR DESCRIPTION
We should be able to post anything that can be rendered as markdown. As long as the thing is markdownable we shouldn't need anyone to specially format it into a slack message first.