### PR TITLE
Move from plain text to slack blocks

### DIFF
--- a/src/slack_message.rs
+++ b/src/slack_message.rs
@@ -4,14 +4,18 @@ use crate::NotificationWithUrl;
 
 /// A Slack message formatted for their incoming webhook API
 ///
+/// https://api.slack.com/block-kit
+///
+/// TODO[Rhys] add support for more block types
+///
 /// # Arguments
 ///
-/// * `text` - The text body of the post; supports markdown formatting
+/// * `blocks` - Individual components (e.g. sections with text, images, etc.) that form the body of the message
 /// * `icon_emoji` - A slack-formatted emoji name that should be used in place of an avatar
 /// * `username` - The username associated with the post
 #[derive(Serialize, Debug)]
 pub struct SlackMessage {
-    text: String,
+    blocks: Vec<SectionBlock>,
     icon_emoji: String,
     username: String,
 }
@@ -19,7 +23,7 @@ pub struct SlackMessage {
 impl SlackMessage {
     pub fn new(text: String) -> Self {
         SlackMessage {
-            text,
+            blocks: vec![SectionBlock::new(text)],
             icon_emoji: ":chart_with_upwards_trend:".to_string(),
             username: "Github Notification Daemon".to_string(),
         }
@@ -36,6 +40,50 @@ impl std::convert::From<&NotificationWithUrl> for SlackMessage {
             url = notification.url,
         );
 
-        SlackMessage::new(message)
+        Self::new(message)
+    }
+}
+
+/// A generic block component that can wrap text, images, or other accessory fields
+///
+/// # Arguments
+///
+/// * `kind` - The type of component that determines how its other fields should be parsed
+/// * `text` - A text field to be rendered as markdown
+#[derive(Serialize, Debug)]
+struct SectionBlock {
+    #[serde(rename = "type")]
+    kind: String,
+    text: TextField,
+}
+
+impl SectionBlock {
+    fn new(text: String) -> Self {
+        Self {
+            kind: String::from("section"),
+            text: TextField::new(text),
+        }
+    }
+}
+
+/// A field of a section block that contains markdown-formatted text
+///
+/// # Arguments
+///
+/// * `kind` - The type of component that determines how its other fields should be parsed
+/// * `text` - The markdown-formatted text to be rendered in the section
+#[derive(Serialize, Debug)]
+struct TextField {
+    #[serde(rename = "type")]
+    kind: String,
+    text: String,
+}
+
+impl TextField {
+    fn new(text: String) -> Self {
+        Self {
+            kind: String::from("mrkdwn"),
+            text,
+        }
     }
 }


### PR DESCRIPTION
Move to using the slack block api for more composable messages.