### PR TITLE
Add module-level doc snippet for future expansion

### DIFF
--- a/src/github_notification.rs
+++ b/src/github_notification.rs
@@ -35,7 +35,7 @@ pub struct GithubNotification {
 
 /// The HTML URL extracted from the response to a github get request to an API URL
 ///
-/// NOTE[Rhys]: There many more fields in the response they depend on what api route we actually hit
+/// NOTE: There many more fields in the response they depend on what api route we actually hit
 #[derive(Deserialize, Debug)]
 pub struct HasHtmlUrl {
     pub html_url: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! A library that provides primitives for working with Github's polling API.
+//! Here's the most important bits:
+//! - [GithubClient](crate::github_client::GithubClient)
+//! - [GithubNotification](crate::github_notification::GithubNotification)
+//!
+//! There are probably other important things, too, but I didn't document those.
 pub use github_client::GithubClient;
 pub use github_notification::{GithubNotification, HasHtmlUrl, NotificationWithUrl};
 pub use slack_client::SlackClient;

--- a/src/slack_message.rs
+++ b/src/slack_message.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 ///
 /// https://api.slack.com/block-kit
 ///
-/// TODO[Rhys] add support for more block types
+/// TODO: add support for more block types
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
This PR also removes square-bracket tags from doc comments, as those are interpreted as Markdown links and result in warnings. You could escape them, but you could also not.