### PR TITLE
Traitify NotificationClient to lay groundwork for future daemon tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 
 [[package]]
+name = "async-trait"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +401,7 @@ dependencies = [
 name = "github_notifications"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1.0.44"
 chrono = "0.4.10"
 futures = "0.3.1"
 log = "0.4.8"
+async-trait = "0.1.21"
 
 [workspace]
 # The executable that uses this library is a member of this workspace so that it

--- a/notification_daemon/src/main.rs
+++ b/notification_daemon/src/main.rs
@@ -6,13 +6,14 @@ use chrono::{Duration, Local};
 
 use github_notifications::*;
 
-use log::{debug, error, info};
+use log::{debug, error};
 
 const POLLING_FREQUENCY: time::Duration = time::Duration::from_secs(30);
 
 /// Pre-main setup.
 fn pre_main() {
     env_logger::init();
+    debug!("Finished pre-main initialization");
 }
 
 #[tokio::main]
@@ -23,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let github_token = env::var("GITHUB_TOKEN").expect("No GITHUB_TOKEN env var.");
     let slack_hook = env::var("SLACK_HOOK").expect("No SLACK_HOOK env var.");
 
-    let github = GithubClient::new(github_username, github_token);
+    let github = NotificationClient::new(github_username, github_token);
     let slack = SlackClient::new(slack_hook);
 
     let prefetch_time: Duration = Duration::hours(1);
@@ -39,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let time_before_fetch = Local::now();
         debug!("Fetching notifications since {:?}", last_fetch_time);
-        let maybe_notifications = github.fetch_notifications(last_fetch_time).await;
+        let maybe_notifications = github.get_humanized_notifications(last_fetch_time).await;
 
         let notifications = match maybe_notifications {
             Ok(notifications) => {

--- a/src/github_client.rs
+++ b/src/github_client.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use chrono::{DateTime, Local};
 use reqwest::Error;
 use reqwest::{Client, Response};
@@ -8,20 +9,29 @@ use futures::future::join_all;
 /// https://developer.github.com/v3/activity/notifications/
 const GITHUB_API_URL: &str = "https://api.github.com/notifications";
 
-/// A client to get messages from the github notification API
+/// A client to get messages from github—or perhaps one day another service's—notification API
 ///
 /// # Arguments
 ///
-/// * `client` - The reqwests client that gets from the github API
+/// * `client` - The `reqwests` client that gets from the github API
 /// * `username` - A github username associated with the token
 /// * `token` - A github personal access token with notification, repo, and non-admin read scopes
-pub struct GithubClient {
+pub struct NotificationClient {
     client: Client,
     username: String,
     token: String,
 }
 
-impl GithubClient {
+#[async_trait]
+pub trait GithubNotificationClient {
+    /// Gets all notifications since a timestamp and bundles them with a human-usable HTML URL.
+    async fn get_humanized_notifications(
+        &self,
+        since: DateTime<Local>,
+    ) -> Result<Vec<NotificationWithUrl>, Error>;
+}
+
+impl NotificationClient {
     pub fn new(username: String, token: String) -> Self {
         Self {
             client: Client::new(),
@@ -30,18 +40,23 @@ impl GithubClient {
         }
     }
 
-    /// Gets all notifications since a timestamp even if they've been read
-    async fn get_notifications(&self, since: DateTime<Local>) -> Result<Response, Error> {
+    /// Gets all notifications since a timestamp, even if they've been read.
+    async fn get_notifications(
+        &self,
+        since: DateTime<Local>,
+    ) -> Result<Vec<GithubNotification>, Error> {
         self.client
             .get(GITHUB_API_URL)
             .basic_auth(&self.username, Some(&self.token))
             .query(&[("since", since.to_rfc3339()), ("all", String::from("true"))])
             .send()
+            .await?
+            .json::<Vec<GithubNotification>>()
             .await
     }
 
     /// Gets a response from an API URL
-    async fn get(&self, api_url: &str) -> Result<Response, Error> {
+    async fn get_api(&self, api_url: &str) -> Result<Response, Error> {
         self.client
             .get(api_url)
             .basic_auth(&self.username, Some(&self.token))
@@ -54,19 +69,19 @@ impl GithubClient {
         &self,
         notification: GithubNotification,
     ) -> Result<NotificationWithUrl, Error> {
-        let response = self.get(&notification.subject.url).await?;
+        let response = self.get_api(&notification.subject.url).await?;
         let url: HasHtmlUrl = response.json::<HasHtmlUrl>().await?;
         Ok(NotificationWithUrl::new(notification, url))
     }
+}
 
-    /// Gets all notifications since a timestamp and bundles them with a human-usable HTML URL
-    pub async fn fetch_notifications(
+#[async_trait]
+impl GithubNotificationClient for NotificationClient {
+    async fn get_humanized_notifications(
         &self,
         since: DateTime<Local>,
     ) -> Result<Vec<NotificationWithUrl>, Error> {
-        let response = self.get_notifications(since).await?;
-        let notifications: Vec<GithubNotification> =
-            response.json::<Vec<GithubNotification>>().await?;
+        let notifications = self.get_notifications(since).await?;
         join_all(
             notifications
                 .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 //! - [GithubNotification](crate::github_notification::GithubNotification)
 //!
 //! There are probably other important things, too, but I didn't document those.
-pub use github_client::GithubClient;
+pub use github_client::GithubNotificationClient;
+pub use github_client::NotificationClient;
 pub use github_notification::{GithubNotification, HasHtmlUrl, NotificationWithUrl};
 pub use slack_client::SlackClient;
 pub use slack_message::SlackMessage;


### PR DESCRIPTION
Testing the library crate (minus deserialization tests) might require us to mock `reqwests` on some level or rethink things to avoid having to do that, which is more work than I want to do right now. This change allows the daemon binary to create its own mock `NotificationClient`, which'll make future daemon logic easier to test.

I've never tested an `async fn` before! I'm looking forward to it.

Depends on #13.